### PR TITLE
Change providers property to access go router state when creating 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ routes: [
   ),
   GoProviderRoute(
     path: '/home',
-    providers: [
+    providers: (state) => [
       ChangeNotifierProvider(create: (_) => UserState()), // or BlocProvider
     ],
     builder: (context, state) => const HomePage(), // ✅ can access UserState
@@ -61,7 +61,7 @@ routes: [
 ```dart
 routes: [
   ShellProviderRoute(
-    providers: [
+    providers: (state) => [
       ChangeNotifierProvider(create: (_) => FooState()), // or BlocProvider
     ],
     builder: (context, state, child) => ShellPage(child: child), // ✅ can access FooState

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,7 @@ final goRouter = GoRouter(
   routes: [
     GoProviderRoute(
       path: '/',
-      providers: [
+      providers: (state) => [ // ✅ can access GoRouterState
         BlocProvider(create: (_) => BlocCubit()),
       ],
       builder: (context, state) => const PageA(), // ✅ can access BlocCubit

--- a/lib/go_provider.dart
+++ b/lib/go_provider.dart
@@ -64,7 +64,7 @@ class ShellProviderRoute extends ShellRoute {
   });
 
   /// A list of providers to be nested in the route.
-  final List<SingleChildWidget> providers;
+  final List<SingleChildWidget> Function(GoRouterState state) providers;
 
   Widget _nest(GoRouterState state, Widget child) {
     return Nested(
@@ -77,7 +77,7 @@ class ShellProviderRoute extends ShellRoute {
         final values = route.pathParameters.map((k) => state.pathParameters[k]);
         return Key(values.toString());
       }(),
-      children: providers,
+      children: providers(state),
       child: child,
     );
   }


### PR DESCRIPTION


fixes #7 



<details><summary>AI Summary</summary>
<p>


This pull request updates the route provider API to allow dynamic access to the current `GoRouterState` when defining providers. This enables providers to be configured based on the route state, making the routing and dependency injection system more flexible.

**API improvements for dynamic providers:**

* Changed the `providers` parameter in `ShellProviderRoute` from a static list to a function that takes a `GoRouterState` and returns a list of providers, allowing providers to be dynamically generated based on the current route state (`lib/go_provider.dart`).
* Updated the usage of `providers` in the route nesting logic to call the function with the current `GoRouterState` instead of using a static list (`lib/go_provider.dart`).
* Updated example usage in `main.dart` to define `providers` as a function that receives the `GoRouterState`, demonstrating how to access route state when creating providers (`example/lib/main.dart`).

</p>
</details> 
